### PR TITLE
Bump actions/upload-artifact to v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
         run: ./benchmark.sh
 
       - name: Upload JMH Results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: jmh-results
           path: reports/*.json


### PR DESCRIPTION
v2 is deprecated and no longer runs as of 2024-06-30

This project is not using any of the action's features that had breaking changes, so just updating the version number should work.