### PR TITLE
Improve benchmark runner options

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,39 @@
+# Nitrite JMH Benchmarks
+
+This repository packages and executes Java Microbenchmark Harness (JMH) suites for different Nitrite versions.
+
+## Benchmark runner
+
+Use the `benchmark.sh` helper to build the project and execute the benchmarks.
+
+### Usage
+
+```bash
+./benchmark.sh [-m modules] [-j "JMH args"]
+```
+
+- `-m` lets you choose a comma-separated list of modules to benchmark (`v3`, `v4`). The default runs both suites.
+- `-j` forwards additional command line options directly to the underlying JMH runner.
+
+The script stores JSON reports under the `reports/` directory.
+
+### Examples
+
+Run every benchmark suite:
+
+```bash
+./benchmark.sh
+```
+
+Run only the Nitrite v4 benchmarks:
+
+```bash
+./benchmark.sh -m v4
+```
+
+Forward additional JMH options:
+
+```bash
+./benchmark.sh -m v3 -j "-wi 5 -i 10 -prof stack"
+```
+

--- a/benchmark.sh
+++ b/benchmark.sh
@@ -1,9 +1,120 @@
 #!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: ./benchmark.sh [-m modules] [-j "JMH args"]
+
+Options:
+  -m modules   Comma-separated list of modules to benchmark (v3, v4).
+               Defaults to both modules.
+  -j "args"    Additional arguments to forward to the JMH runner.
+  -h           Show this help message and exit.
+USAGE
+}
+
+selected_modules=("v3" "v4")
+declare -a jmh_args=()
+
+while getopts ":m:j:h" opt; do
+  case "${opt}" in
+    m)
+      if [[ -z "${OPTARG}" ]]; then
+        echo "Error: -m requires a comma-separated list of modules." >&2
+        usage
+        exit 1
+      fi
+
+      IFS=',' read -r -a parsed_modules <<< "${OPTARG}"
+      selected_modules=()
+      for module in "${parsed_modules[@]}"; do
+        module="${module//[[:space:]]/}"
+        if [[ -z "${module}" ]]; then
+          continue
+        fi
+        case "${module}" in
+          v3|nitrite-v3)
+            selected_modules+=("v3")
+            ;;
+          v4|nitrite-v4)
+            selected_modules+=("v4")
+            ;;
+          *)
+            echo "Error: Unknown module '${module}'." >&2
+            usage
+            exit 1
+            ;;
+        esac
+      done
+
+      if (( ${#selected_modules[@]} == 0 )); then
+        echo "Error: No valid modules specified." >&2
+        usage
+        exit 1
+      fi
+      ;;
+    j)
+      if [[ -n "${OPTARG}" ]]; then
+        read -r -a jmh_args <<< "${OPTARG}"
+      else
+        jmh_args=()
+      fi
+      ;;
+    h)
+      usage
+      exit 0
+      ;;
+    :)
+      echo "Error: Option -${OPTARG} requires an argument." >&2
+      usage
+      exit 1
+      ;;
+    ?)
+      echo "Error: Invalid option -${OPTARG}." >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+shift $((OPTIND - 1))
+
+if (( $# > 0 )); then
+  echo "Error: Unexpected arguments: $*" >&2
+  usage
+  exit 1
+fi
 
 mvn package
 
-mkdir reports
+mkdir -p reports
 
-java -jar nitrite-v3/target/benchmarks.jar -rf json -rff reports/nitrite-v3.json
+for module in "${selected_modules[@]}"; do
+  case "${module}" in
+    v3)
+      module_dir="nitrite-v3"
+      ;;
+    v4)
+      module_dir="nitrite-v4"
+      ;;
+    *)
+      echo "Error: Unsupported module identifier '${module}'." >&2
+      exit 1
+      ;;
+  esac
 
-java -jar nitrite-v4/target/benchmarks.jar -rf json -rff reports/nitrite-v4.json
+  jar_path="${module_dir}/target/benchmarks.jar"
+  if [[ ! -f "${jar_path}" ]]; then
+    echo "Error: Benchmark jar not found for ${module_dir}: ${jar_path}" >&2
+    exit 1
+  fi
+
+  report_file="reports/${module_dir}.json"
+  cmd=("java" "-jar" "${jar_path}" "-rf" "json" "-rff" "${report_file}")
+  if (( ${#jmh_args[@]} > 0 )); then
+    cmd+=("${jmh_args[@]}")
+  fi
+
+  echo "Running benchmarks for ${module_dir}..."
+  "${cmd[@]}"
+done
+


### PR DESCRIPTION
## Summary
- add getopts-based argument parsing to `benchmark.sh` to select modules and forward JMH options
- dynamically build benchmark commands and validate benchmark artifacts before execution
- document the benchmark helper usage and examples in a new README section

## Testing
- ./benchmark.sh -h

------
https://chatgpt.com/codex/tasks/task_e_68c879fc670c8320b74f88e5418078e3